### PR TITLE
Custom exclude nca

### DIFF
--- a/R/exclude_nca.R
+++ b/R/exclude_nca.R
@@ -227,3 +227,82 @@ exclude_nca_tmax_early <- function(tmax_early = 0) {
 exclude_nca_tmax_0 <- function() {
   exclude_nca_tmax_early()
 }
+
+
+#' Exclude NCA Results Based on Parameter Thresholds
+#'
+#' Exclude rows from NCA results based on specified thresholds for a given parameter.
+#' This function allows users to define minimum and/or maximum acceptable values
+#' for a parameter and excludes rows that fall outside these thresholds.
+#'
+#' @param parameter The name of the PKNCA parameter to evaluate (e.g., "span.ratio").
+#' @param min_thr The minimum acceptable value for the parameter. If not provided, is not applied.
+#' @param max_thr The maximum acceptable value for the parameter. If not provided, is not applied.
+#' @param affected_parameters Character vector of PKNCA parameters that will be marked as excluded.
+#'                            By default is the defined parameter.
+#' @returns A function that can be used with `PKNCA::exclude` to mark through the 'exclude'  column
+#'          the rows in the PKNCA results based on the specified thresholds for a parameter.
+#' @examples
+#' # Example dataset
+#' my_data <- PKNCA::PKNCAdata(
+#'   PKNCA::PKNCAconc(data.frame(conc = c(1, 2, 3, 4),
+#'                               time = c(0, 1, 2, 3),
+#'                               subject = 1),
+#'                    conc ~ time | subject),
+#'   PKNCA::PKNCAdose(data.frame(subject = 1, dose = 100, time = 0),
+#'                    dose ~ time | subject)
+#' )
+#' my_result <- PKNCA::pk.nca(my_data)
+#'
+#' # Exclude rows where span.ratio is less than 100
+#' excluded_result <- PKNCA::exclude(
+#'   my_result,
+#'   FUN = exclude_nca_by_param("span.ratio", min_thr = 100)
+#' )
+#' as.data.frame(excluded_result)
+#'
+#' @export
+
+exclude_nca_by_param <- function(
+  parameter,
+  min_thr = NULL,
+  max_thr = NULL,
+  affected_parameters = parameter
+) {
+  # Determine if thresholds are defined and if so check they are single numeric objects
+  is_min_thr <- is_single_numeric(min_thr, "min_thr")
+  is_max_thr <- is_single_numeric(max_thr, "max_thr")
+
+  if (isTRUE(min_thr > max_thr))
+    stop("if both defined min_thr must be less than max_thr")
+
+  function(x, ...) {
+    ret <- rep(NA_character_, nrow(x))
+    idx_param <- which(x$PPTESTCD == parameter)
+    idx_aff_params <- which(x$PPTESTCD %in% affected_parameters)
+
+    if (length(idx_param) > 1)
+      stop("Should not see more than one ", parameter, " (please report this as a bug)")
+
+    if (length(idx_param) == 1 && !is.na(x$PPORRES[idx_param]) && length(idx_aff_params) > 0) {
+      current_value <- x$PPORRES[idx_param]
+      pretty_name <- parameter # Pretty name did not convince me for some parameters (e.g, "r.squared")
+      if (is_min_thr && current_value < min_thr) {
+        ret[idx_aff_params] <- sprintf("%s < %g", pretty_name, min_thr)
+      } else if (is_max_thr && current_value > max_thr) {
+        ret[idx_aff_params] <- sprintf("%s > %g", pretty_name, max_thr)
+      }
+    }
+    ret
+  }
+}
+
+# Helper function to validate if a value is a single numeric and check if it is defined
+is_single_numeric <- function(value, name) {
+  is_val <- any(!is.null(value) & !is.na(value) & !missing(value))
+  if (is_val && (length(value) != 1 || !is.numeric(value))) {
+    stop(sprintf("when defined %s must be a single numeric value", name))
+  }
+  is_val
+}
+

--- a/tests/testthat/test-exclude_nca.R
+++ b/tests/testthat/test-exclude_nca.R
@@ -109,3 +109,102 @@ test_that("exclude_nca_tmax_early", {
     fixed = TRUE
   )
 })
+
+test_that("exclude_nca_by_param works as expected", {
+  # Define the input
+  my_result <- FIXTURE_PKNCA_RES %>%
+    filter(USUBJID == 2) %>%
+    mutate(PPTESTCD = translate_terms(PPTESTCD, "PPTESTCD", "PKNCA")) %>%
+    filter(PPTESTCD %in% c("cmax", "span.ratio"))
+
+  # excludes rows based on min_thr
+  res_min_excluded <- PKNCA::exclude(
+    my_result,
+    FUN = exclude_nca_by_param("span.ratio", min_thr = 100)
+  )
+  expect_equal(
+    as.data.frame(res_min_excluded)$exclude,
+    c(NA, "Lambda z Span < 100", NA, "Lambda z Span < 100")
+  )
+
+  # does not exclude rows when min_thr is not met
+  res_min_not_excluded <- PKNCA::exclude(
+    my_result,
+    FUN = exclude_nca_by_param("span.ratio", min_thr = 0.01)
+  )
+  expect_equal(
+    as.data.frame(res_min_not_excluded)$exclude,
+    rep(NA_character_, 4)
+  )
+
+  # excludes rows based on max_thr
+  res_max_excluded <- PKNCA::exclude(
+    my_result,
+    FUN = exclude_nca_by_param("span.ratio", max_thr = 0.01)
+  )
+  expect_equal(
+    as.data.frame(res_max_excluded)$exclude,
+    c(NA, "Lambda z Span > 0.01", NA, "Lambda z Span > 0.01")
+  )
+
+  # does not exclude rows when max_thr is not exceeded
+  res_max_not_excluded <- PKNCA::exclude(
+    my_result,
+    FUN = exclude_nca_by_param("span.ratio", max_thr = 100)
+  )
+  expect_equal(
+    as.data.frame(res_max_not_excluded)$exclude,
+    rep(NA_character_, 4)
+  )
+
+  # throws an error for invalid min_thr
+  expect_error(
+    exclude_nca_by_param("span.ratio", min_thr = "invalid"),
+    "when defined min_thr must be a single numeric value"
+  )
+
+  # throws an error for invalid max_thr
+  expect_error(
+    exclude_nca_by_param(parameter = "span.ratio", max_thr = c(1, 2)),
+    "when defined max_thr must be a single numeric value"
+  )
+
+  # throws an error when min_thr is greater than max_thr
+  expect_error(
+    exclude_nca_by_param("span.ratio", min_thr = 10, max_thr = 5),
+    "if both defined min_thr must be less than max_thr"
+  )
+
+  # returns the original object when the parameter is not found
+  res <- PKNCA::exclude(my_result, FUN = exclude_nca_by_param("nonexistent", min_thr = 0))
+  expect_true(all(is.na(as.data.frame(res)$exclude)))
+
+  # returns the object when the parameter's value is NA
+  my_result_na <- my_result
+  my_result_na$result$PPORRES <- NA
+  res <- PKNCA::exclude(
+    my_result_na,
+    FUN = exclude_nca_by_param("span.ratio", min_thr = 0)
+  )
+  expect_true(all(is.na(as.data.frame(res)$exclude)))
+
+  # marks records associated with the affected_parameters
+  res <- PKNCA::exclude(
+    my_result,
+    FUN = exclude_nca_by_param(
+      "span.ratio", min_thr = 0.01, affected_parameters = c("cmax", "span.ratio")
+    )
+  )
+  # All span.ratio records should be NA (not excluded)
+  expect_true(all(is.na(as.data.frame(res)$exclude[res$result$PPTESTCD == "span.ratio"])))
+
+  # produces an error when more than 1 PPORRES is per parameter (should never happen in real code)
+  expect_error(
+    exclude_nca_by_param(
+      param = "r.squared",
+      min_thr = 0.7
+    )(data.frame(PPTESTCD = "r.squared", PPORRES = c(1, 1))),
+    regexp = "Should not see more than one r.squared (please report this as a bug)",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-exclude_nca.R
+++ b/tests/testthat/test-exclude_nca.R
@@ -8,12 +8,12 @@ test_that("exclude_nca", {
   my_result_excluded <- exclude(my_result, FUN=exclude_nca_max.aucinf.pext())
   expect_equal(as.data.frame(my_result_excluded)$exclude,
                c(rep(NA_character_, nrow(my_result_excluded$result)-2),
-                 rep("aucpext.obs > 20", 2)))
+                 rep("aucpext > 20", 2)))
 
   my_result_excluded <- exclude(my_result, FUN=exclude_nca_max.aucinf.pext(50))
   expect_equal(as.data.frame(my_result_excluded)$exclude,
                c(rep(NA_character_, nrow(my_result_excluded$result)-2),
-                 rep("aucpext.obs > 50", 2)))
+                 rep("aucpext > 50", 2)))
 
   my_result_excluded <- exclude(my_result, FUN=exclude_nca_span.ratio())
   expect_equal(as.data.frame(my_result_excluded)$exclude,

--- a/tests/testthat/test-exclude_nca.R
+++ b/tests/testthat/test-exclude_nca.R
@@ -8,39 +8,39 @@ test_that("exclude_nca", {
   my_result_excluded <- exclude(my_result, FUN=exclude_nca_max.aucinf.pext())
   expect_equal(as.data.frame(my_result_excluded)$exclude,
                c(rep(NA_character_, nrow(my_result_excluded$result)-2),
-                 rep("AUC percent extrapolated > 20", 2)))
+                 rep("aucpext.obs > 20", 2)))
 
   my_result_excluded <- exclude(my_result, FUN=exclude_nca_max.aucinf.pext(50))
   expect_equal(as.data.frame(my_result_excluded)$exclude,
                c(rep(NA_character_, nrow(my_result_excluded$result)-2),
-                 rep("AUC percent extrapolated > 50", 2)))
+                 rep("aucpext.obs > 50", 2)))
 
   my_result_excluded <- exclude(my_result, FUN=exclude_nca_span.ratio())
   expect_equal(as.data.frame(my_result_excluded)$exclude,
                c(rep(NA_character_, 4),
-                 rep("Span ratio < 2", 11)))
+                 rep("span.ratio < 2", 11)))
   my_result_excluded <- exclude(my_result, FUN=exclude_nca_span.ratio(1))
   expect_equal(as.data.frame(my_result_excluded)$exclude,
                c(rep(NA_character_, 4),
-                 rep("Span ratio < 1", 11)))
+                 rep("span.ratio < 1", 11)))
 
   my_result_excluded <- exclude(my_result, FUN=exclude_nca_min.hl.r.squared())
   expect_equal(as.data.frame(my_result_excluded)$exclude,
                c(rep(NA_character_, 4),
-                 rep("Half-life r-squared < 0.9", 11)))
+                 rep("r.squared < 0.9", 11)))
   my_result_excluded <- exclude(my_result, FUN=exclude_nca_min.hl.r.squared(0.95))
   expect_equal(as.data.frame(my_result_excluded)$exclude,
                c(rep(NA_character_, 4),
-                 rep("Half-life r-squared < 0.95", 11)))
+                 rep("r.squared < 0.95", 11)))
 
   my_result_excluded <- exclude(my_result, FUN=exclude_nca_min.hl.adj.r.squared())
   expect_equal(as.data.frame(my_result_excluded)$exclude,
                c(rep(NA_character_, 4),
-                 rep("Half-life adj. r-squared < 0.9", 11)))
+                 rep("adj.r.squared < 0.9", 11)))
   my_result_excluded <- exclude(my_result, FUN=exclude_nca_min.hl.adj.r.squared(0.95))
   expect_equal(as.data.frame(my_result_excluded)$exclude,
                c(rep(NA_character_, 4),
-                 rep("Half-life adj. r-squared < 0.95", 11)))
+                 rep("adj.r.squared < 0.95", 11)))
 
   my_data <- PKNCAdata(my_conc, intervals=data.frame(start=0, end=Inf, cmax=TRUE))
   suppressMessages(
@@ -58,6 +58,28 @@ test_that("exclude_nca", {
   expect_equal(my_result,
                exclude(my_result, FUN=exclude_nca_min.hl.adj.r.squared()),
                info="Result is ignored when not calculated")
+})
+
+test_that("exclude_nca_max.aucinf.pext", {
+  my_conc <- PKNCAconc(data.frame(conc=c(1.1^(3:0), 1.1), time=0:4, subject=1), conc~time|subject)
+  my_data <- PKNCAdata(my_conc, intervals=data.frame(start=0, end=Inf, aucpext.pred=TRUE, aucpext.obs=TRUE))
+  suppressMessages(
+    my_result <- pk.nca(my_data)
+  )
+  expect_equal(
+    as.data.frame(my_result)$exclude,
+    rep(NA_character_, nrow(as.data.frame(my_result)))
+  )
+  my_result_exclude_20 <- exclude(my_result, FUN = exclude_nca_max.aucinf.pext(max.aucinf.pext = 20))
+  expect_equal(
+    as.data.frame(my_result_exclude_20)$exclude,
+    c(rep(NA_character_, nrow(as.data.frame(my_result_exclude_20))-4), rep("aucpext > 20", 4))
+  )
+  my_result_exclude_50 <- exclude(my_result, FUN = exclude_nca_max.aucinf.pext(max.aucinf.pext = 50))
+  expect_equal(
+    as.data.frame(my_result_exclude_50)$exclude,
+    c(rep(NA_character_, nrow(as.data.frame(my_result_exclude_50))-4), rep("aucpext > 50", 4))
+  )
 })
 
 test_that("exclude_nca_count_conc_measured", {
@@ -78,7 +100,7 @@ test_that("exclude_nca_count_conc_measured", {
   my_result_exclude10 <- exclude(my_result, FUN = exclude_nca_count_conc_measured(min_count = 10))
   expect_equal(
     as.data.frame(my_result_exclude10)$exclude,
-    c("Number of measured concentrations is < 10", rep(NA_character_, 13), rep("Number of measured concentrations is < 10", 2))
+    c("count_conc_measured < 10", rep(NA_character_, 13), rep("count_conc_measured < 10", 2))
   )
 })
 
@@ -95,12 +117,12 @@ test_that("exclude_nca_tmax_early", {
   my_result_exclude_1 <- exclude(my_result, FUN = exclude_nca_tmax_early(tmax_early = 1))
   expect_equal(
     as.data.frame(my_result_exclude_1)$exclude,
-    rep("Tmax is <=1 (likely missed dose, insufficient PK samples, or PK sample swap)", nrow(as.data.frame(my_result_exclude_1)))
+    rep("tmax < 1 (likely missed dose, insufficient PK samples, or PK sample swap)", nrow(as.data.frame(my_result_exclude_1)))
   )
   my_result_exclude_0 <- exclude(my_result, FUN = exclude_nca_tmax_0())
   expect_equal(
     as.data.frame(my_result_exclude_0)$exclude,
-    rep("Tmax is <=0 (likely missed dose, insufficient PK samples, or PK sample swap)", nrow(as.data.frame(my_result_exclude_0)))
+    rep("tmax <= 0 (likely missed dose, insufficient PK samples, or PK sample swap)", nrow(as.data.frame(my_result_exclude_0)))
   )
   # This should never happen in real code
   expect_error(


### PR DESCRIPTION


Introduction of `exclude_nca_by_param`: A generic function to centralize logic for excluding results based on parameter thresholds. I have two proposals on how to use this function, however please feel free to just choose one (or none) of them if they don't seem useful. I can reset my commits. I would suggest using this function for:

- `User use`. The function will allow users to customize their exclusion criteria  for their results as well as the affected parameters. This can be helpful for users with special needs or interests.
- `Code refactoring`. I recommend using it to build the other `exclude_nca` specific functions. This in my opinion will simplify: 1) Simplify code maintenance and future developments, 2) Reduce redundancy in the testing files, 3) Homogenize the functions behavior, which currently was for example using different strategies in the parameter names for the exclusion messages. 

### Other changes relevant to mention and/or discuss:
- `Names to use for the parameters`. In the exclusion messages at first I was thinking in using something as the `pretty names`. However, they won't seem great for certain parameters (i.e, `adj.r.squared`)

* **Special case for `exclude_nca_tmax`:** This function will work as the others and its message will be `tmax < X` instead of `tmax <= X`. However, if it is mandatory there are easy solutions to solve this like the one in `exclude_nca_tmax_0`

